### PR TITLE
fix: remove help command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ const program: Command = new Command();
 program
   .name("zetachain")
   .description("CLI tool for ZetaChain development.")
-  .helpCommand(false);
+  .helpCommand(false)
   .version(config.version);
 
 program.addCommand(accountsCommand);

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ const program: Command = new Command();
 program
   .name("zetachain")
   .description("CLI tool for ZetaChain development.")
-  .version("dev");
+  .version("dev")
+  .helpCommand(false);
 
 program.addCommand(newCommand);
 program.addCommand(localnetCommand);


### PR DESCRIPTION
For namespaces like `accounts`, `solana`, etc. `help` will have to be disabled in the Toolkit.