### PR TITLE
ci: correctly set next tag on npm

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -46,6 +46,6 @@ jobs:
         if: steps.determine-npm-tag.outputs.NPM_TAG == 'latest'
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          npm dist-tag add your-package@$VERSION next
+          npm dist-tag add zetachain@$VERSION next
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
npm failed to assign a `next` tag because the package name wasn't provided correctly.

https://github.com/zeta-chain/cli/actions/runs/15309360878/job/43070038881

I've manually set 4.0.0 as `next`, but this fix will ensure it's set automatically next time.