### PR TITLE
ci: fix permissions for pr labeler workflow

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,10 +1,12 @@
 name: PR Conventional Commit Validation
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, edited]
 
 permissions:
+  pull-requests: read
+  contents: read
   issues: write
 
 jobs:
@@ -14,4 +16,5 @@ jobs:
       - name: PR Conventional Commit Validation
         uses: ytanikin/pr-conventional-commits@1.4.1
         with:
-          task_types: '["feat","fix","docs","test","ci","refactor","chore", "dependabot"]'
+          task_types: '["feat","fix","docs","test","ci","refactor","chore","dependabot"]'
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
To allow it to label PRs created by dependabot, like this one: https://github.com/zeta-chain/cli/pull/39