### PR TITLE
chore: update localnet to v13.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/zeta-chain/cli#readme",
   "dependencies": {
-    "@zetachain/localnet": "12.0.3",
+    "@zetachain/localnet": "^13.1.0",
     "@zetachain/toolkit": "16.1.2",
     "axios": "^1.7.7",
     "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/zeta-chain/cli#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.17.4",
-    "@zetachain/localnet": "13.1.1-rc1",
+    "@zetachain/localnet": "^13.1.1",
     "@zetachain/toolkit": "16.1.2",
     "axios": "^1.7.7",
     "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/zeta-chain/cli#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "1.17.4",
-    "@zetachain/localnet": "^13.1.1",
+    "@zetachain/localnet": "13.1.1",
     "@zetachain/toolkit": "16.1.2",
     "axios": "^1.7.7",
     "commander": "^13.1.0",

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "homepage": "https://github.com/zeta-chain/cli#readme",
   "dependencies": {
-    "@zetachain/localnet": "^13.1.0",
     "@modelcontextprotocol/sdk": "1.17.4",
+    "@zetachain/localnet": "13.1.1-rc1",
     "@zetachain/toolkit": "16.1.2",
     "axios": "^1.7.7",
     "commander": "^13.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2615,10 +2615,10 @@
   dependencies:
     "@wallet-standard/base" "^1.1.0"
 
-"@zetachain/localnet@12.0.3":
-  version "12.0.3"
-  resolved "https://registry.yarnpkg.com/@zetachain/localnet/-/localnet-12.0.3.tgz#0fe16056bddbd43d7ac67affd03913e1c19aed7b"
-  integrity sha512-X/wojUMi8Pw5r8hULNaIeexEYv40HfyQPjKW71YZ0PfkpkNz18iGNjMn0ZVGgRtJT/ToxOh4gS1udooqwlbkGg==
+"@zetachain/localnet@^13.1.0":
+  version "13.1.0"
+  resolved "https://registry.npmjs.org/@zetachain/localnet/-/localnet-13.1.0.tgz#d92f38e0da895e0c3e2e853d0e5f3d23ccbb984f"
+  integrity sha512-utE5CVrLzxKR9EgqhYhcEKJVhJPOiUXTXKLXhrk6QgjEYBK49jbus2HQ+6WdPj3cqaEWXGz7FZ58JxcmCWjNwg==
   dependencies:
     "@coral-xyz/anchor" "^0.30.1"
     "@inquirer/prompts" "^5.5.0"
@@ -2652,6 +2652,7 @@
     js-sha256 "^0.11.0"
     simple-git "^3.27.0"
     sudo-prompt "^9.2.1"
+    table "^6.9.0"
     wait-on "^7.2.0"
     winston "^3.17.0"
     zod "^3.24.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2959,10 +2959,10 @@
   dependencies:
     "@wallet-standard/base" "^1.1.0"
 
-"@zetachain/localnet@13.1.1-rc1":
-  version "13.1.1-rc1"
-  resolved "https://registry.npmjs.org/@zetachain/localnet/-/localnet-13.1.1-rc1.tgz#9d4af938a68fa212bc96dbd23061fd0377201891"
-  integrity sha512-ijBBJBkPo5Si9PBzS8gKiadK+66FuMkIa7k76oYxnJzGnnEFtiWlYfAOQpkYsMTs7NCRra8dMcMEZJxwxLYwlw==
+"@zetachain/localnet@^13.1.1":
+  version "13.1.1"
+  resolved "https://registry.npmjs.org/@zetachain/localnet/-/localnet-13.1.1.tgz#947e292efe4892bb19de25188f132f51886f7a21"
+  integrity sha512-Irjrdh0wfGPUKkosVVlLrMP9+U/Iocs/uLcIaQxfdrhSby67BCs8xsFmmWtlt4+gbANcj0UxGLKdm26AOzAstA==
   dependencies:
     "@coral-xyz/anchor" "^0.30.1"
     "@inquirer/prompts" "^5.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2959,7 +2959,7 @@
   dependencies:
     "@wallet-standard/base" "^1.1.0"
 
-"@zetachain/localnet@^13.1.1":
+"@zetachain/localnet@13.1.1":
   version "13.1.1"
   resolved "https://registry.npmjs.org/@zetachain/localnet/-/localnet-13.1.1.tgz#947e292efe4892bb19de25188f132f51886f7a21"
   integrity sha512-Irjrdh0wfGPUKkosVVlLrMP9+U/Iocs/uLcIaQxfdrhSby67BCs8xsFmmWtlt4+gbANcj0UxGLKdm26AOzAstA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2959,10 +2959,10 @@
   dependencies:
     "@wallet-standard/base" "^1.1.0"
 
-"@zetachain/localnet@^13.1.0":
-  version "13.1.0"
-  resolved "https://registry.npmjs.org/@zetachain/localnet/-/localnet-13.1.0.tgz#d92f38e0da895e0c3e2e853d0e5f3d23ccbb984f"
-  integrity sha512-utE5CVrLzxKR9EgqhYhcEKJVhJPOiUXTXKLXhrk6QgjEYBK49jbus2HQ+6WdPj3cqaEWXGz7FZ58JxcmCWjNwg==
+"@zetachain/localnet@13.1.1-rc1":
+  version "13.1.1-rc1"
+  resolved "https://registry.npmjs.org/@zetachain/localnet/-/localnet-13.1.1-rc1.tgz#9d4af938a68fa212bc96dbd23061fd0377201891"
+  integrity sha512-ijBBJBkPo5Si9PBzS8gKiadK+66FuMkIa7k76oYxnJzGnnEFtiWlYfAOQpkYsMTs7NCRra8dMcMEZJxwxLYwlw==
   dependencies:
     "@coral-xyz/anchor" "^0.30.1"
     "@inquirer/prompts" "^5.5.0"


### PR DESCRIPTION
Contains fixes to the contract registry on Localnet.

Used in standard and example contracts.